### PR TITLE
⬆️ build.gradle.kts: update android gradle plugin - KOCHA-222

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object Apps {
 }
 
 object Versions {
-    const val gradle = "7.2.1"
+    const val gradle = "7.3.1"
     const val kotlin = "1.7.0"
     const val compose = "1.1.1"
     const val ktlintGradle = "10.3.0"

--- a/sample-learning-app/build.gradle.kts
+++ b/sample-learning-app/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 val version = getAppVersion()
 
 android {
+    namespace = "com.eidu.integration.sample.app"
     compileSdk = Apps.compileSdk
     buildToolsVersion = Apps.buildToolsVersion
 

--- a/sample-learning-app/src/main/AndroidManifest.xml
+++ b/sample-learning-app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.eidu.integration.sample.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".IntegrationSampleApplication"


### PR DESCRIPTION
**Asana Task**
[app.asana.com/0/1201864995605426/1202487961427389/f](https://app.asana.com/0/1201864995605426/1202487961427389/f)

**Background**
AGP versions <7.3 have a vulnerability. This PR updates the plugin to version the most recent version 7.3.1

**Notes**
This PR also moves the namespace to the gradle build file, having it in the Manifest is deprecated.